### PR TITLE
quickfix attempt at Windows tracker start without name==main guard

### DIFF
--- a/docs/integrations/standalone.md
+++ b/docs/integrations/standalone.md
@@ -47,6 +47,8 @@ for a more detailed actual usage example.
 It's possible to track only the system-wide or process resource usage by the
 related init parameters of `ResourceTracker`, just like controlling the sampling
 interval, or how to start (e.g. spawn or fork) the subprocesses of the trackers.
+On Windows, background trackers are started via a dedicated worker subprocess so
+you do not need an `if __name__ == "__main__":` guard in your script.
 
 For even more control, you can use the underlying `ProcessTracker` and
 `SystemTracker` classes directly, which are not starting and handling new

--- a/src/resource_tracker/_tracker_worker.py
+++ b/src/resource_tracker/_tracker_worker.py
@@ -1,0 +1,54 @@
+"""Subprocess entry point for background ResourceTracker workers.
+
+On Windows, ``ResourceTracker`` starts tracker workers via ``python -m
+resource_tracker._tracker_worker`` so the user's main script is not re-imported
+during multiprocessing bootstrap.
+"""
+
+import argparse
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "tracker_type",
+        choices=["process", "system"],
+        help="Which tracker to run in the background.",
+    )
+    parser.add_argument("--start-time", type=float, required=True)
+    parser.add_argument("--interval", type=float, required=True)
+    parser.add_argument("--output-file", required=True)
+    parser.add_argument("--error-file", required=True)
+    parser.add_argument("--pid", type=int)
+    parser.add_argument(
+        "--children",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Track child processes (process tracker only).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.tracker_type == "process" and args.pid is None:
+        parser.error("--pid is required for the process tracker")
+
+    from .tracker import _run_tracker
+
+    kwargs = {
+        "start_time": args.start_time,
+        "interval": args.interval,
+        "output_file": args.output_file,
+    }
+    if args.tracker_type == "process":
+        kwargs["pid"] = args.pid
+        kwargs["children"] = args.children
+
+    _run_tracker(
+        args.tracker_type,
+        error_queue=None,
+        error_file=args.error_file,
+        **kwargs,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/resource_tracker/helpers.py
+++ b/src/resource_tracker/helpers.py
@@ -12,6 +12,7 @@ from importlib.util import find_spec
 from io import StringIO
 from multiprocessing import Process
 from os import unlink
+from subprocess import Popen
 from re import search
 from subprocess import PIPE, Popen, TimeoutExpired
 from typing import Any, Callable, Dict, Iterable, List, Union
@@ -143,6 +144,28 @@ def cleanup_processes(processes: List[Process]):
                 process.join(timeout=1.0)
         with suppress(Exception):
             process.close()
+
+
+def cleanup_workers(workers: List[Union[Process, Popen]]):
+    """Terminate background tracker workers started as processes or subprocesses.
+
+    Args:
+        workers: ``multiprocessing.Process`` or ``subprocess.Popen`` objects.
+    """
+    for worker in workers:
+        if worker is None:
+            continue
+        if isinstance(worker, Popen):
+            with suppress(Exception):
+                if worker.poll() is None:
+                    worker.terminate()
+                    worker.wait(timeout=1.0)
+            with suppress(Exception):
+                if worker.poll() is None:
+                    worker.kill()
+                    worker.wait(timeout=1.0)
+        else:
+            cleanup_processes([worker])
 
 
 def aggregate_stats(

--- a/src/resource_tracker/helpers.py
+++ b/src/resource_tracker/helpers.py
@@ -12,7 +12,6 @@ from importlib.util import find_spec
 from io import StringIO
 from multiprocessing import Process
 from os import unlink
-from subprocess import Popen
 from re import search
 from subprocess import PIPE, Popen, TimeoutExpired
 from typing import Any, Callable, Dict, Iterable, List, Union

--- a/src/resource_tracker/tracker.py
+++ b/src/resource_tracker/tracker.py
@@ -45,7 +45,7 @@ from .column_maps import (
 from .helpers import (
     aggregate_stats,
     cleanup_files,
-    cleanup_processes,
+    cleanup_workers,
     get_tracker_implementation,
     is_psutil_available,
     render_csv_row,
@@ -394,7 +394,7 @@ class SystemTracker:
                 file_handle.close()
 
 
-def _run_tracker(tracker_type, error_queue, **kwargs):
+def _run_tracker(tracker_type, error_queue=None, error_file=None, **kwargs):
     """Run either ProcessTracker or SystemTracker with dynamic import resolution and error handling.
 
     This functions is standalone so that it can be pickled by multiprocessing,
@@ -446,14 +446,17 @@ def _run_tracker(tracker_type, error_queue, **kwargs):
         from sys import exc_info, exit
 
         exc_info = exc_info()
-        error_queue.put(
-            {
-                "name": exc_info[0].__name__,
-                "module": exc_info[0].__module__,
-                "message": str(exc_info[1]),
-                "traceback": traceback.format_exception(*exc_info),
-            }
-        )
+        error_data = {
+            "name": exc_info[0].__name__,
+            "module": exc_info[0].__module__,
+            "message": str(exc_info[1]),
+            "traceback": traceback.format_exception(*exc_info),
+        }
+        if error_queue is not None:
+            error_queue.put(error_data)
+        elif error_file:
+            with open(error_file, "w", encoding="utf-8") as handle:
+                handle.write(json_dumps(error_data))
         exit(1)
 
 
@@ -469,7 +472,7 @@ class ResourceTracker:
         children: Whether to track child processes. Defaults to True.
         interval: Sampling interval in seconds. Defaults to 1.
         method: Multiprocessing method. Defaults to None, which tries to fork on
-            Linux and macOS, and spawn on Windows.
+            Linux and macOS, and uses a dedicated worker subprocess on Windows.
         autostart: Whether to start tracking immediately. Defaults to True.
         track_processes: Whether to track resource usage at the process level.
             Defaults to True.
@@ -546,18 +549,26 @@ class ResourceTracker:
                 "psutil is required for resource tracking on non-Linux platforms"
             )
 
-        if method is None:
-            # try to fork when possible due to leaked semaphores on older Python versions
-            # see e.g. https://github.com/python/cpython/issues/90549
-            if platform in ["linux", "darwin"]:
-                self.mpc = get_context("fork")
-            else:
-                self.mpc = get_context("spawn")
-        else:
-            self.mpc = get_context(method)
+        # On Windows, use ``python -m resource_tracker._tracker_worker`` instead
+        # of multiprocessing spawn so the user's main script is not re-imported.
+        self._use_subprocess_workers = platform == "win32"
 
-        # error details from subprocesses
-        self.error_queue = self.mpc.SimpleQueue()
+        if self._use_subprocess_workers:
+            self.mpc = None
+            self.error_queue = None
+        else:
+            if method is None:
+                # try to fork when possible due to leaked semaphores on older Python versions
+                # see e.g. https://github.com/python/cpython/issues/90549
+                if platform in ["linux", "darwin"]:
+                    self.mpc = get_context("fork")
+                else:
+                    self.mpc = get_context("spawn")
+            else:
+                self.mpc = get_context(method)
+
+            # error details from subprocesses
+            self.error_queue = self.mpc.SimpleQueue()
 
         # create temporary CSV file(s) for the tracker(s), and record only the file path(s)
         # to be passed later to subprocess(es) avoiding pickling the file object(s)
@@ -578,6 +589,66 @@ class ResourceTracker:
         if autostart:
             self.start()
 
+    def _start_subprocess_worker(self, tracker_type: str) -> None:
+        """Start a tracker worker via ``python -m resource_tracker._tracker_worker``."""
+        from subprocess import DEVNULL, Popen
+        from sys import executable
+
+        short_type = "process" if tracker_type == "process_tracker" else "system"
+        error_temp = NamedTemporaryFile(delete=False, suffix=".json")
+        error_path = error_temp.name
+        error_temp.close()
+        setattr(self, f"{tracker_type}_error_filepath", error_path)
+
+        cmd = [
+            executable,
+            "-m",
+            "resource_tracker._tracker_worker",
+            short_type,
+            "--start-time",
+            str(self.start_time),
+            "--interval",
+            str(self.interval),
+            "--output-file",
+            getattr(self, f"{tracker_type}_filepath"),
+            "--error-file",
+            error_path,
+        ]
+        if short_type == "process":
+            cmd.extend(["--pid", str(self.pid)])
+            if not self.children:
+                cmd.append("--no-children")
+
+        setattr(
+            self,
+            f"{tracker_type}_process",
+            Popen(cmd, stdout=DEVNULL, stderr=DEVNULL),
+        )
+
+    def _collect_worker_errors(self) -> List[dict]:
+        """Return error payloads reported by background tracker workers."""
+        errors = []
+        if self.error_queue is not None:
+            if not self.error_queue.empty():
+                errors.append(self.error_queue.get())
+            return errors
+
+        for tracker_name in self.trackers:
+            error_path = getattr(self, f"{tracker_name}_error_filepath", None)
+            if error_path and path.isfile(error_path) and path.getsize(error_path) > 0:
+                with open(error_path, encoding="utf-8") as handle:
+                    errors.append(json_loads(handle.read()))
+        return errors
+
+    @staticmethod
+    def _log_worker_error(error_data: dict) -> None:
+        logger.warning(
+            "Resource tracker subprocess failed!\n"
+            f"Error type: {error_data['name']} (from module {error_data['module']})\n"
+            f"Error message: {error_data['message']}\n"
+            f"Original traceback:\n{error_data['traceback']}"
+        )
+
     def start(self):
         """Start the selected resource trackers in the background as subprocess(es)."""
         if self.running:
@@ -595,33 +666,39 @@ class ResourceTracker:
         if self.start_time - time() < 0.05:
             self.start_time += self.interval
 
-        if "process_tracker" in self.trackers:
-            self.process_tracker_process = self.mpc.Process(
-                target=_run_tracker,
-                args=("process", self.error_queue),
-                kwargs={
-                    "pid": self.pid,
-                    "start_time": self.start_time,
-                    "interval": self.interval,
-                    "children": self.children,
-                    "output_file": self.process_tracker_filepath,
-                },
-                daemon=True,
-            )
-            self.process_tracker_process.start()
+        if self._use_subprocess_workers:
+            if "process_tracker" in self.trackers:
+                self._start_subprocess_worker("process_tracker")
+            if "system_tracker" in self.trackers:
+                self._start_subprocess_worker("system_tracker")
+        else:
+            if "process_tracker" in self.trackers:
+                self.process_tracker_process = self.mpc.Process(
+                    target=_run_tracker,
+                    args=("process", self.error_queue),
+                    kwargs={
+                        "pid": self.pid,
+                        "start_time": self.start_time,
+                        "interval": self.interval,
+                        "children": self.children,
+                        "output_file": self.process_tracker_filepath,
+                    },
+                    daemon=True,
+                )
+                self.process_tracker_process.start()
 
-        if "system_tracker" in self.trackers:
-            self.system_tracker_process = self.mpc.Process(
-                target=_run_tracker,
-                args=("system", self.error_queue),
-                kwargs={
-                    "start_time": self.start_time,
-                    "interval": self.interval,
-                    "output_file": self.system_tracker_filepath,
-                },
-                daemon=True,
-            )
-            self.system_tracker_process.start()
+            if "system_tracker" in self.trackers:
+                self.system_tracker_process = self.mpc.Process(
+                    target=_run_tracker,
+                    args=("system", self.error_queue),
+                    kwargs={
+                        "start_time": self.start_time,
+                        "interval": self.interval,
+                        "output_file": self.system_tracker_filepath,
+                    },
+                    daemon=True,
+                )
+                self.system_tracker_process.start()
 
         def collect_server_info():
             """Collect server info to be run in a background thread."""
@@ -647,7 +724,7 @@ class ResourceTracker:
         # make sure to cleanup the started subprocess(es)
         finalize(
             self,
-            cleanup_processes,
+            cleanup_workers,
             [
                 getattr(self, f"{tracker_name}_process")
                 for tracker_name in self.trackers
@@ -725,7 +802,7 @@ class ResourceTracker:
             if hasattr(self, "_combined_csv_filepath"):
                 cleanup_files([self._combined_csv_filepath])
         with suppress(Exception):
-            cleanup_processes(
+            cleanup_workers(
                 [
                     getattr(self, f"{tracker_name}_process")
                     for tracker_name in self.trackers
@@ -743,21 +820,15 @@ class ResourceTracker:
                 streaming is enabled.  Defaults to ``"finished"``.
         """
         self.stop_time = time()
-        # check for errors in the subprocesses
-        if not self.error_queue.empty():
-            error_data = self.error_queue.get()
-            logger.warning(
-                "Resource tracker subprocess failed!\n"
-                f"Error type: {error_data['name']} (from module {error_data['module']})\n"
-                f"Error message: {error_data['message']}\n"
-                f"Original traceback:\n{error_data['traceback']}"
-            )
+        for error_data in self._collect_worker_errors():
+            self._log_worker_error(error_data)
         # terminate tracker processes
         for tracker_name in self.trackers:
             process_attr = f"{tracker_name}_process"
             if hasattr(self, process_attr):
-                cleanup_processes([getattr(self, process_attr)])
-        self.error_queue.close()
+                cleanup_workers([getattr(self, process_attr)])
+        if self.error_queue is not None:
+            self.error_queue.close()
 
         # Finalize streaming — flush remaining data and call finish_run
         if self._streaming is not None:

--- a/tests/test_tracker_streaming.py
+++ b/tests/test_tracker_streaming.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import gzip
+from time import time
 from unittest.mock import patch
 
 import pytest
@@ -30,13 +31,16 @@ FAKE_REGISTER_RESPONSE = {
 }
 
 
-def _wait_for_tracker(tracker, timeout=5):
-    """Spin-wait until at least one sample has been collected."""
-    for _ in range(timeout * 10):
-        if tracker.n_samples > 0:
-            return
+def _wait_for_tracker(tracker, timeout=5, min_samples=1):
+    """Spin-wait until at least ``min_samples`` have been collected."""
+    deadline = time() + timeout
+    while tracker.n_samples < min_samples:
+        if time() > deadline:
+            pytest.fail(
+                f"Only {tracker.n_samples} sample(s) collected after {timeout} seconds "
+                f"(expected at least {min_samples})"
+            )
         cpu_single(duration=0.1)
-    pytest.fail(f"No data collected after {timeout} seconds")
 
 
 # ---------------------------------------------------------------------------
@@ -215,7 +219,7 @@ def test_update_combined_csv_appends_rows(mock_register, monkeypatch):
     assert "process_" in lines[0]
 
     # Wait for more samples and update again — should only append
-    cpu_single(duration=1.5)
+    _wait_for_tracker(tracker, timeout=15, min_samples=tracker.n_samples + 1)
     tracker._update_combined_csv()
     n_second = tracker._combined_csv_rows_written
     assert n_second > n_first

--- a/tests/test_tracker_windows.py
+++ b/tests/test_tracker_windows.py
@@ -1,0 +1,79 @@
+"""Tests for Windows-safe background tracker startup."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from resource_tracker import ResourceTracker
+
+
+@pytest.fixture
+def windows_tracker():
+    with patch("resource_tracker.tracker.platform", "win32"):
+        with patch("resource_tracker.tracker.is_psutil_available", return_value=True):
+            yield ResourceTracker()
+
+
+def test_windows_uses_subprocess_workers(windows_tracker):
+    assert windows_tracker._use_subprocess_workers is True
+    assert windows_tracker.mpc is None
+    assert windows_tracker.error_queue is None
+
+
+@patch("subprocess.Popen")
+def test_windows_start_launches_worker_module(mock_popen, windows_tracker):
+    mock_proc = MagicMock()
+    mock_popen.return_value = mock_proc
+
+    windows_tracker.start()
+
+    worker_calls = [
+        call
+        for call in mock_popen.call_args_list
+        if "resource_tracker._tracker_worker" in call.args[0]
+    ]
+    assert len(worker_calls) == 2
+    for call in worker_calls:
+        cmd = call.args[0]
+        assert cmd[1:3] == ["-m", "resource_tracker._tracker_worker"]
+        assert cmd[3] in {"process", "system"}
+        assert "--error-file" in cmd
+        assert "--output-file" in cmd
+
+    windows_tracker.stop()
+    mock_proc.terminate.assert_called()
+
+
+def test_tracker_worker_module_runs_process_tracker(tmp_path):
+    from resource_tracker._tracker_worker import main
+
+    output_file = tmp_path / "process.csv"
+    error_file = tmp_path / "error.json"
+
+    with patch("resource_tracker.tracker._run_tracker") as mock_run_tracker:
+        main(
+            [
+                "process",
+                "--start-time",
+                "0",
+                "--interval",
+                "1",
+                "--output-file",
+                str(output_file),
+                "--error-file",
+                str(error_file),
+                "--pid",
+                "1234",
+            ]
+        )
+
+    mock_run_tracker.assert_called_once_with(
+        "process",
+        error_queue=None,
+        error_file=str(error_file),
+        start_time=0.0,
+        interval=1.0,
+        children=True,
+        output_file=str(output_file),
+        pid=1234,
+    )


### PR DESCRIPTION
This helps spawning issue when user runs a script without the `if __name__ == "__main__"` guard on Windows. Low priority -- let's properly review and only merge if really needed and not adding too much maintenance burden.